### PR TITLE
Extend the EC2 instance features

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.63.0"
+  hashes = [
+    "h1:jGnSBSPCBaDmu9MCu3eyPJBPCobae2XaFib8OQ2C5OA=",
+    "h1:mhVxzwfSZVxPJNZsr1fvKZe51+48BdM7pzWChVQ4v68=",
+    "zh:21f3a6870dd80b8312b6aac28784b29a7c2cf072175f0de943f09bddbf14cad6",
+    "zh:28feb0621baeaa9b6992a6209fd0d7ad1c665b1dd895123f2fd36d91d69d116f",
+    "zh:301d51b398c3e3488ea2b63defeb254436854c83046d9fc5ca129b13faaa4319",
+    "zh:343e89645a2b23363226e2e0571639637ac1ddf7fa8c562bf883b17c8ad30d7d",
+    "zh:56c89148fc105a1bf32ffcd574ec1e679144377ea26c9ae4211dd491a3def358",
+    "zh:5e3b88e3eb28b23819126d43b191a2bda28a09d7690aee7e577b3b6235c4824a",
+    "zh:64c21f3b38a8f0f0ef8b938df71cde76d77e010236bb6a0b46f66daa6cab6f99",
+    "zh:6869e5fafe6535954ac75ece63e9765d6b12d1752b54cf9639a01585f1a5583e",
+    "zh:90a6894868c585a5abf00e784723d74ea80aff3d0403b36028c4b08c5c4894d6",
+    "zh:92e9e4b7c183e518c1decd0fbc780e9f1941d05710c9c20329c78556a7f0adac",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bbc053d060d4f6e95ef60549a0e92487fbbd88807f8161507cc389edc7dde0f7",
+    "zh:cfd8e88029a2fdafdfa77688f966705ade9211d173cbb6aa1552839c9993c19a",
+    "zh:d291875c26a6a05b60e02f1481c296269080232fa0ae86cce5caa04a6df82ed6",
+    "zh:f42f0b81587de0c51859e37cd671c442d8eaf42558d83c6421b1e46549576f89",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# infra-terraform
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_tf-state-backend-s3"></a> [tf-state-backend-s3](#module\_tf-state-backend-s3) | ./tfinternal | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_dynamodb_table.tf_state_s3_locks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_elb.ci-sockshop-k8s-elb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elb) | resource |
+| [aws_iam_policy.LS-DenyPolicy--e782738e0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.ec2_with_admin_roleLS-DenyPolicy--e782738e0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_instance.ci-sockshop-k8s-master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_instance.ci-sockshop-k8s-node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_instance.demo-instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_internet_gateway.gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+| [aws_key_pair.demo-instance-keypair](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
+| [aws_route.route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_s3_bucket.tf_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_public_access_block.tf_state_s3_public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.tf_state_s3_bucket_sse](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.tf_state_s3_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_security_group.demo-instance-sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.k8s-security-group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_subnet.demo-subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.demo-vpc-01](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [aws_ami.amzn-linux-2023-ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_iam_role.ec2withadminrole](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instance_public_dns"></a> [instance\_public\_dns](#output\_instance\_public\_dns) | Output the public DNS of the instance |
+<!-- END_TF_DOCS -->

--- a/ec2-server.tf
+++ b/ec2-server.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "ap-south-1"
+}
+
 # Setup a VPC for the EC2 instance
 resource "aws_vpc" "demo-vpc-01" {
   cidr_block = "172.16.0.0/16"
@@ -7,17 +11,36 @@ resource "aws_vpc" "demo-vpc-01" {
   }
 }
 
+
+
 # Declare subnets within the VPC to place
 # the EC2 instance in
 resource "aws_subnet" "demo-subnet" {
   vpc_id            = aws_vpc.demo-vpc-01.id
   cidr_block        = "172.16.10.0/24"
-  availability_zone = "us-east-2a"
+  availability_zone = "ap-south-1a"
 
   tags = {
     Name = "srr-tf-demo-subnet"
   }
 }
+
+resource "aws_internet_gateway" "gateway" {
+  vpc_id = aws_vpc.demo-vpc-01.id
+
+  tags = {
+    Name = "internet-gateway-for-demo-vpc-01"
+  }
+}
+
+resource "aws_route" "route" {
+  route_table_id         = aws_vpc.demo-vpc-01.main_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gateway.id
+}
+
+data "aws_availability_zones" "available" {}
+
 
 # Use this data block to filter out the
 # AWS AMI images for the EC2 linux instance
@@ -31,6 +54,34 @@ data "aws_ami" "amzn-linux-2023-ami" {
   }
 }
 
+resource "aws_key_pair" "demo-instance-keypair" {
+  key_name   = "demo-instance-keypair"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCfbcUu+oAvtj4yu77xYSUIk+2kxVfOpXOosLBgYOc5ZOz7KJFImDElyRuql6Pvi9pFgNEIDfcCLqHkHnh/UV2zMeDbjwzRGOgM2MsKADdWKw03HseZkD2MywG40Mh8pelzYiYducqkpCK4LnSpqLbtTcko2A4rzrIuiojyu3HsdoQLBPC/FBQECq6MauQ6/eeonk4Xn9t9hCvbFVmNUFeRNl2ypvPbAdOwCf6UrikDJImRsUYJk+jpbN51ZCVash8XeWoQm3HhENDzK6IUuk8mTJR1uJRvWOoXpck12Ae2qAw1nc9YR5Grk+/6wbp3XTE6ep1OUFfPezhuQoA2Ze+FThOuvJClIf6S+ZajTFETDywgFFnjvndXGS8vlKvQDZXiS2bmx/Xf3bCb3SiX6imtF3MsJxu2s2cKrQdjwQUWakQRxAGvq083MLm0QfFx+8ncF20IxSZm0zw57ENbbZV9ZFugztT9Fuw9oVujRHCDwiV0LYkzi2vSZ1eMKGvKg+s= sairohith@DESKTOP-M4L9POK"
+}
+
+resource "aws_security_group" "demo-instance-sg" {
+  name        = "demo-instance-sg"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = "${aws_vpc.demo-vpc-01.id}"
+
+  ingress {
+    # TLS (change to whatever ports you need)
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    # Please restrict your ingress to only necessary IPs and ports.
+    # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
+    cidr_blocks = ["183.82.109.207/32"]
+  }
+
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+  }
+}
+
 # Provision the EC2 instance of type t2.small
 # within the subnet created above, and the ami
 # filtered by the data block
@@ -38,9 +89,20 @@ resource "aws_instance" "demo-instance" {
   ami           = data.aws_ami.amzn-linux-2023-ami.id
   instance_type = "t2.small"
   subnet_id     = aws_subnet.demo-subnet.id
+  key_name = aws_key_pair.demo-instance-keypair.key_name
+  associate_public_ip_address = true
+  vpc_security_group_ids = [aws_security_group.demo-instance-sg.id]
 
   tags = {
     Name = "srr-tf-demo-ec2"
     Environment = "Demo"
   }
+
+  
 }
+
+# Output the public DNS of the instance
+output "instance_public_dns" {
+  value = aws_instance.demo-instance.public_dns
+}
+


### PR DESCRIPTION
This PR updates the Terraform file with more code.

## Description from PR2D2
This PR updates the `ec2-server.tf` file to enhance the network setup and security configurations for the EC2 instance. The changes include the introduction of a provider block, an internet gateway, a route for internet access, a key pair for SSH access, and a security group to control traffic.

#### Related Issues
- No related issues were found

#### Changes Made

- Provider Configuration: Added a provider block to set the AWS region to `ap-south-1`.
- VPC Configuration: The existing VPC configuration remains unchanged.
- Subnet Configuration: Updated the availability zone for the subnet from `us-east-2a` to `ap-south-1a`.
- Internet Gateway and Route: Added an `aws_internet_gateway` resource to enable internet access for the VPC. Added an `aws_route` resource to route outbound traffic to the internet via the internet gateway.
- Security Enhancements: Introduced an `aws_security_group` resource to allow inbound SSH traffic on port 22 from a specific IP (`183.82.109.207/32`). Configured the security group to allow all outbound traffic.
- Key Pair: Created an `aws_key_pair` resource for SSH access to the EC2 instance with a specified public key.
- EC2 Instance Configuration:  Added `key_name` to associate the instance with the created key pair. Configured the instance to associate a public IP address. Added a security group to the instance to manage inbound and outbound traffic.
- Outputs: Added an output block to display the public DNS of the EC2 instance.